### PR TITLE
Fix an samples error

### DIFF
--- a/samples/python/find_obj.py
+++ b/samples/python/find_obj.py
@@ -125,7 +125,7 @@ def explore_match(win, img1, img2, kp_pairs, status = None, H = None):
             kp1s, kp2s = [], []
             for i in idxs:
                 (x1, y1), (x2, y2) = p1[i], p2[i]
-                col = (red, green)[status[i][0]]
+                col = (red, green)[status[i]]
                 cv.line(cur_vis, (x1, y1), (x2, y2), col)
                 kp1, kp2 = kp_pairs[i]
                 kp1s.append(kp1)


### PR DESCRIPTION
Once i was click the feature point When asift is running,the console print "IndexError: invalid index to scalar variable" in line 128,so i check the code and fix it.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
