### PR TITLE
Update houghcircles.py

### DIFF
--- a/samples/python/houghcircles.py
+++ b/samples/python/houghcircles.py
@@ -32,7 +32,7 @@ def main():
     if circles is not None: # Check if circles have been found and only then iterate over these and add them to the image
         _a, b, _c = circles.shape
         for i in range(b):
-            cv.circle(cimg, (circles[0][i][0], circles[0][i][1]), circles[0][i][2], (0, 0, 255), 3, cv.LINE_AA)
+            cv.circle(cimg, (circles[0][i][0], circles[0][i][1]), int(circles[0][i][2]), (0, 0, 255), 3, cv.LINE_AA)
             cv.circle(cimg, (circles[0][i][0], circles[0][i][1]), 2, (0, 255, 0), 3, cv.LINE_AA)  # draw center of circle
 
         cv.imshow("detected circles", cimg)


### PR DESCRIPTION
The cv.circle function argument 'radius' is required to be an integer,but circles[0][i][2] returns a class 'numpy.float32'.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or other license that is incompatible with OpenCV
- [x] The PR is proposed to proper branch
- [x] There is reference to original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
